### PR TITLE
Bug Fixes and Fitter Specification

### DIFF
--- a/pta_replicator/deterministic.py
+++ b/pta_replicator/deterministic.py
@@ -4,8 +4,8 @@ import ephem
 import astropy as ap
 from astropy.time import TimeDelta
 from astropy import units as u
-from astropy.cosmology import Planck18 as cosmo
-from holodeck import utils
+# from astropy.cosmology import Planck18 as cosmo
+from holodeck import utils, cosmo
 from pta_replicator.red_noise import add_gwb
 
 from numba import njit, prange

--- a/pta_replicator/deterministic.py
+++ b/pta_replicator/deterministic.py
@@ -192,12 +192,39 @@ def add_catalog_of_cws(psr, gwtheta_list, gwphi_list, mc_list, dist_list, fgw_li
     ----------
     psr : Pulsar object
     gwtheta_list : 1Darray
-        list of CW source theta's
+        List of polar angles of GW sources in celestial coords [radians]
     gwphi_list : 1Darray
+        List of azimuthal angles of GW sources in celestial coords [radians]
     mc_list : 1Darray
-        list of observed CW source chirp masses 
+        List of observed chirp masses of SMBHBs [solar masses] 
     dist_list : 1Darray
-        list of observed CW source luminosity distances
+        List of luminosity distances to SMBHBs [Mpc]
+    fgw_list : 1Darray
+        List of observed frequencies of GW (twice the orbital frequency) [Hz]
+    phase0_list : 1Darray
+        List of initial phases of GW sources [radians]
+    psi_list : 1Darray
+        List of polarizations of GW sources [radians]
+    inc_list : 1Darray
+        List of inclinations of GW sources [radians]
+    pdist : float
+        Pulsar distance to use other than those in psr [kpc]
+    pphase : float?
+        Use pulsar phase to determine distance [radian]
+    psrTerm : bool
+        Option to include pulsar term [boolean]
+    evolve : bool
+        Option to exclude evolution [boolean]
+    tref:  
+        Fidicuial time at which initial parameters are referenced
+    chunk_size : int
+        default 10_000_000
+    signal_name : str
+        default 'cw_catalog'
+
+    Returns
+    -------
+    None
     
     """
 

--- a/pta_replicator/red_noise.py
+++ b/pta_replicator/red_noise.py
@@ -171,8 +171,6 @@ def add_gwb(
     for psr in psrs:
         psr.update_added_signals('{}_gwb'.format(psr.name), 
                                  {'amplitude': log10_amplitude, 'spectral_index': spectral_index})
-    Amp = 10**log10_amplitude
-    gam = spectral_index
     if seed is not None:
         np.random.seed(seed)
 
@@ -242,7 +240,9 @@ def add_gwb(
 
     # strain amplitude
     if userSpec is None:
-
+        Amp = 10**log10_amplitude
+        gam = spectral_index
+    
         f1yr = 1 / 3.16e7
         alpha = -0.5 * (gam - 3)
         hcf = Amp * (f / f1yr) ** (alpha)

--- a/pta_replicator/simulate.py
+++ b/pta_replicator/simulate.py
@@ -46,8 +46,11 @@ class SimulatedPulsar:
             self.f = pint.fitter.GLSFitter(self.toas, self.model)
         elif fitter == 'downhill':
             self.f = pint.fitter.DownhillGLSFitter(self.toas, self.model)
-        else:
+        elif fitter == 'auto':
             self.f = pint.fitter.Fitter.auto(self.toas, self.model)
+        else:
+            err = f"{fitter=} must be one of 'wls', 'gls', 'downhill' or 'auto'"
+            raise ValueError(err)
         
         self.f.fit_toas(max_chi2_increase=max_chi2_increase, min_lambda=min_lambda)
         self.model = self.f.model

--- a/pta_replicator/simulate.py
+++ b/pta_replicator/simulate.py
@@ -37,9 +37,16 @@ class SimulatedPulsar:
         """Method to take the current TOAs and model and update the residuals with them"""
         self.residuals = Residuals(self.toas, self.model)
 
-    def fit(self, max_chi2_increase=1e-2, min_lambda=1e-3, fitter='auto'):
+    def fit(self, fitter='auto', **fitter_kwargs):
         """
         Refit the timing model and update everything
+
+        Parameters
+        ----------
+        fitter : str
+            Type of fitter to use [auto]
+        fitter_kwargs :
+            Kwargs to pass onto fit_toas. Can be useful to set parameters such as max_chi2_increase, min_lambda, etc.
         """
         if fitter == 'wls':
             self.f = pint.fitter.WLSFitter(self.toas, self.model)
@@ -53,7 +60,7 @@ class SimulatedPulsar:
             err = f"{fitter=} must be one of 'wls', 'gls', 'downhill' or 'auto'"
             raise ValueError(err)
         
-        self.f.fit_toas(max_chi2_increase=max_chi2_increase, min_lambda=min_lambda)
+        self.f.fit_toas(**fitter_kwargs)
         self.model = self.f.model
         self.update_residuals()
 

--- a/pta_replicator/simulate.py
+++ b/pta_replicator/simulate.py
@@ -2,6 +2,7 @@
 Code to make simulated PTA datasets with PINT
 Created by Bence Becsy, Jeff Hazboun, Aaron Johnson
 With code adapted from libstempo (Michele Vallisneri)
+
 """
 import glob
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pint-pulsar = "^0.9.0"
+pint-pulsar = "^0.9.8"
 numpy = "^1.26.4"
 astropy = "^6.0.0"
 scipy = "^1.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pint-pulsar = "^0.9.8"
+pint-pulsar = "^0.9.0"
 numpy = "^1.26.4"
 astropy = "^6.0.0"
 scipy = "^1.12.0"


### PR DESCRIPTION
1. cosmo error
Previously, the line `dc = cosmo.z_to_dcom(rz)` in `deterministic.add_gwb_plus_outliers` raised the following error:
> AttributeError: 'FlatLambdaCDM' object has no attribute 'z_to_dcom'

I resolved this by importing cosmo from holodeck instead of using Planck18 from astropy.cosmology. Any other cosmo that does include the z_to_dcom function would be a sufficient alternative bug fix. 

2. userSpec 10**log10_amplitude error
Previously, the line `Amp = 10**log10_amplitude` raised the following error if you have a None value for log10_amplitude:
> TypeError: unsupported operand type(s) for ** or pow(): 'int' and 'NoneType'

When providing a userSpec instead of a powerlaw gwb it can be convenient to pass in None for log10_amplitude and spectral_index. To allow for this, I moved the `Amp = 10**log10_amplitude` line inside the `if userSpec is None` block.

3. Fitter specification 
Pass a command line argument to pulsar.fit() allowing the user to specify a particular pint fitter they would like to use, instead of the auto selected one. Also, let the user pass in the max_chi2_increase and min_lambda to the pint fit_toas funcition.