### PR TITLE
Let `SimulatedPulsar` store residuals from each added signal

### DIFF
--- a/pta_replicator/deterministic.py
+++ b/pta_replicator/deterministic.py
@@ -46,22 +46,6 @@ def add_cgw(
     :param evolve: Option to exclude evolution [boolean]
     :param tref: Fidicuial time at which initial parameters are referenced
     """
-    
-    psr.update_added_signals('{}_'.format(psr.name)+signal_name,
-                             {'gwtheta': gwtheta,
-                              'gwphi':gwphi,
-                              'mc':mc,
-                              'dist':dist,
-                              'fgw':fgw,
-                              'phase0':phase0,
-                              'psi':psi,
-                              'inc':inc,
-                              'pdist':pdist,
-                              'pphase':pphase,
-                              'psrTerm':psrTerm,
-                              'evolve':evolve,
-                              'phase_approx':phase_approx,
-                              'tref':tref})
 
     # convert units
     mc *= SOLAR2S  # convert from solar masses to seconds
@@ -179,6 +163,24 @@ def add_cgw(
         res = -fplus * rplus - fcross * rcross
 
     dt = res * u.s
+    
+    psr.update_added_signals('{}_'.format(psr.name)+signal_name,
+                             {'gwtheta': gwtheta,
+                              'gwphi':gwphi,
+                              'mc':mc,
+                              'dist':dist,
+                              'fgw':fgw,
+                              'phase0':phase0,
+                              'psi':psi,
+                              'inc':inc,
+                              'pdist':pdist,
+                              'pphase':pphase,
+                              'psrTerm':psrTerm,
+                              'evolve':evolve,
+                              'phase_approx':phase_approx,
+                              'tref':tref},
+                             dt)
+    
     psr.toas.adjust_TOAs(TimeDelta(dt.to('day')))
     psr.update_residuals()
 
@@ -228,22 +230,6 @@ def add_catalog_of_cws(psr, gwtheta_list, gwphi_list, mc_list, dist_list, fgw_li
     
     """
 
-    psr.update_added_signals('{}_'.format(psr.name)+signal_name,
-                             {'gwtheta_list': gwtheta_list,
-                              'gwphi_list':gwphi_list,
-                              'mc_list':mc_list,
-                              'dist_list':dist_list,
-                              'fgw_list':fgw_list,
-                              'phase0_list':phase0_list,
-                              'psi_list':psi_list,
-                              'inc_list':inc_list,
-                              'pdist':pdist,
-                              'pphase':pphase,
-                              'psrTerm':psrTerm,
-                              'evolve':evolve,
-                              'phase_approx':phase_approx,
-                              'tref':tref})
-
     # pulsar location
     if "RAJ" and "DECJ" in psr.loc.keys():
         ptheta = np.pi / 2 - psr.loc["DECJ"]*np.pi/180.0
@@ -283,6 +269,24 @@ def add_catalog_of_cws(psr, gwtheta_list, gwphi_list, mc_list, dist_list, fgw_li
                                          pdist=pdist, pphase=pphase, psrTerm=psrTerm, evolve=evolve, phase_approx=phase_approx)
             #add current batch to TOAs
             dt = res * u.s
+            
+            psr.update_added_signals('{}_'.format(psr.name)+signal_name,
+                                     {'gwtheta_list': gwtheta_list,
+                                      'gwphi_list':gwphi_list,
+                                      'mc_list':mc_list,
+                                      'dist_list':dist_list,
+                                      'fgw_list':fgw_list,
+                                      'phase0_list':phase0_list,
+                                      'psi_list':psi_list,
+                                      'inc_list':inc_list,
+                                      'pdist':pdist,
+                                      'pphase':pphase,
+                                      'psrTerm':psrTerm,
+                                      'evolve':evolve,
+                                      'phase_approx':phase_approx,
+                                      'tref':tref},
+                                     dt)
+            
             psr.toas.adjust_TOAs(TimeDelta(dt.to('day')))
             psr.update_residuals()
     else:
@@ -292,6 +296,24 @@ def add_catalog_of_cws(psr, gwtheta_list, gwphi_list, mc_list, dist_list, fgw_li
         #End of loop over CW sources
         #Now add residual to TOAs
         dt = res * u.s
+        
+        psr.update_added_signals('{}_'.format(psr.name)+signal_name,
+                                 {'gwtheta_list': gwtheta_list,
+                                  'gwphi_list':gwphi_list,
+                                  'mc_list':mc_list,
+                                  'dist_list':dist_list,
+                                  'fgw_list':fgw_list,
+                                  'phase0_list':phase0_list,
+                                  'psi_list':psi_list,
+                                  'inc_list':inc_list,
+                                  'pdist':pdist,
+                                  'pphase':pphase,
+                                  'psrTerm':psrTerm,
+                                  'evolve':evolve,
+                                  'phase_approx':phase_approx,
+                                  'tref':tref},
+                                 dt)
+        
         psr.toas.adjust_TOAs(TimeDelta(dt.to('day')))
         psr.update_residuals()
 
@@ -707,15 +729,6 @@ def add_burst(psr, gwtheta, gwphi, waveform_plus, waveform_cross, psi=0.0, tref=
     :returns: Vector of induced residuals
     """
 
-    psr.update_added_signals('{}_'.format(psr.name)+signal_name,
-                             {'gwtheta': gwtheta,
-                              'gwphi':gwphi,
-                              'waveform_plus':waveform_plus,
-                              'waveform_cross':waveform_cross,
-                              'psi':psi,
-                              'tref':tref,
-                              'remove_quad':remove_quad})
-
     # define variable for later use
     cosgwtheta, cosgwphi = np.cos(gwtheta), np.cos(gwphi)
     singwtheta, singwphi = np.sin(gwtheta), np.sin(gwphi)
@@ -765,6 +778,17 @@ def add_burst(psr, gwtheta, gwphi, waveform_plus, waveform_cross, psi=0.0, tref=
         res = res - pp[0]*toas**2 -pp[1]*toas - pp[2]
 
     dt = res * u.s
+    
+    psr.update_added_signals('{}_'.format(psr.name)+signal_name,
+                             {'gwtheta': gwtheta,
+                              'gwphi':gwphi,
+                              'waveform_plus':waveform_plus,
+                              'waveform_cross':waveform_cross,
+                              'psi':psi,
+                              'tref':tref,
+                              'remove_quad':remove_quad},
+                             dt)
+    
     psr.toas.adjust_TOAs(TimeDelta(dt.to('day')))
     psr.update_residuals()
 
@@ -778,10 +802,6 @@ def add_noise_transient(psr, waveform, tref=0, signal_name='noise_transient'):
     :returns: Vector of induced residuals
     """
 
-    psr.update_added_signals('{}_'.format(psr.name)+signal_name,
-                             {'waveform':waveform,
-                              'tref':tref})
-
     # get toas from pulsar object
     toas = psr.toas.get_mjds().value * 86400 - tref
 
@@ -789,6 +809,12 @@ def add_noise_transient(psr, waveform, tref=0, signal_name='noise_transient'):
     res = waveform(toas)
 
     dt = res * u.s
+    
+    psr.update_added_signals('{}_'.format(psr.name)+signal_name,
+                             {'waveform':waveform,
+                              'tref':tref},
+                             dt)
+    
     psr.toas.adjust_TOAs(TimeDelta(dt.to('day')))
     psr.update_residuals()
 
@@ -803,13 +829,6 @@ def add_gw_memory(psr, strain, gwtheta, gwphi, bwm_pol, t0_mjd, signal_name='gw_
     :param bwm_pol: Polarization angle [radians]
     :param t0_mjd: Burst epoch [MJD]
     """
-
-    psr.update_added_signals('{}_'.format(psr.name)+signal_name,
-                             {'strain':strain,
-                              'gwtheta': gwtheta,
-                              'gwphi':gwphi,
-                              'bwm_pol':bwm_pol,
-                              't0_mjd':t0_mjd})
 
     # define variable for later use
     cosgwtheta, cosgwphi = np.cos(gwtheta), np.cos(gwphi)
@@ -852,5 +871,14 @@ def add_gw_memory(psr, strain, gwtheta, gwphi, bwm_pol, t0_mjd, signal_name='gw_
         # print(type(toa))
         dt[toa_idx] = 0 if toa < t0_sec else (pol * strain * (toa - t0_sec))
     dt = dt*u.s
+    
+    psr.update_added_signals('{}_'.format(psr.name)+signal_name,
+                             {'strain':strain,
+                              'gwtheta': gwtheta,
+                              'gwphi':gwphi,
+                              'bwm_pol':bwm_pol,
+                              't0_mjd':t0_mjd},
+                             dt)
+    
     psr.toas.adjust_TOAs(TimeDelta(dt.to('day')))
     psr.update_residuals()

--- a/pta_replicator/red_noise.py
+++ b/pta_replicator/red_noise.py
@@ -109,8 +109,6 @@ def add_red_noise(psr: SimulatedPulsar, log10_amplitude: float, spectral_index: 
     """Add red noise with P(f) = A^2 / (12 pi^2) (f * year)^-gamma,
     using `components` Fourier bases.
     Optionally take a pseudorandom-number-generator seed."""
-    psr.update_added_signals('{}_red_noise'.format(psr.name), 
-                             {'amplitude': log10_amplitude, 'spectral_index': spectral_index})
     A = 10**(log10_amplitude)
     gamma = spectral_index
     # nobs = len(psr.toas.table)
@@ -128,6 +126,11 @@ def add_red_noise(psr: SimulatedPulsar, log10_amplitude: float, spectral_index: 
     prior = A**2 * (freqs/fyr)**(-gamma) / (12 * np.pi**2 * Tspan) * YEAR_IN_SEC**3
     y = np.sqrt(prior) * np.random.randn(freqs.size)
     dt = np.dot(F,y) * u.s
+    
+    psr.update_added_signals('{}_red_noise'.format(psr.name), 
+                             {'amplitude': log10_amplitude, 'spectral_index': spectral_index},
+                             dt)
+    
     psr.toas.adjust_TOAs(TimeDelta(dt.to('day')))
     psr.update_residuals()
 
@@ -168,9 +171,6 @@ def add_gwb(
     :param howml: Lowest frequency is 1/(howml * T)
     :returns: list of residuals for each pulsar
     """
-    for psr in psrs:
-        psr.update_added_signals('{}_gwb'.format(psr.name), 
-                                 {'amplitude': log10_amplitude, 'spectral_index': spectral_index})
 
     if seed is not None:
         np.random.seed(seed)
@@ -291,5 +291,8 @@ def add_gwb(
     for psr in psrs:
         dt = res_gw[ct] / 86400.0 * u.day
         psr.toas.adjust_TOAs(TimeDelta(dt.to('day')))
+        psr.update_added_signals('{}_gwb'.format(psr.name), 
+                                 {'amplitude': log10_amplitude, 'spectral_index': spectral_index},
+                                 dt)
         psr.update_residuals()
         ct += 1

--- a/pta_replicator/simulate.py
+++ b/pta_replicator/simulate.py
@@ -13,6 +13,7 @@ from pint.residuals import Residuals
 import pint.toa as toa
 from pint import models
 import pint.fitter
+import tqdm
 
 from enterprise.pulsar import Pulsar
 
@@ -29,6 +30,7 @@ class SimulatedPulsar:
     name: str = None
     loc: dict = None
     added_signals: dict = None
+    added_signals_time: dict = None
 
     def __repr__(self):
         return f"SimulatedPulsar({self.name})"
@@ -72,13 +74,15 @@ class SimulatedPulsar:
         else:
             self.toas.write_TOA_file(outtim)
 
-    def update_added_signals(self, signal_name, param_dict):
+    def update_added_signals(self, signal_name, param_dict, dt=None):
         """
         Update the timing model with a new signal
         """
         if signal_name in self.added_signals:
             raise ValueError(f"{signal_name} already exists in the model.")
         self.added_signals[signal_name] = param_dict
+        if dt is not None:
+            self.added_signals_time[signal_name] = dt
 
     def to_enterprise(self, ephem='DE440'):
         """
@@ -150,4 +154,5 @@ def make_ideal(psr: SimulatedPulsar, iterations: int = 2):
         residuals = Residuals(psr.toas, psr.model)
         psr.toas.adjust_TOAs(TimeDelta(-1.0*residuals.time_resids))
     psr.added_signals = {}
+    psr.added_signals_time = {}
     psr.update_residuals()

--- a/pta_replicator/white_noise.py
+++ b/pta_replicator/white_noise.py
@@ -70,15 +70,7 @@ def add_measurement_noise(psr: SimulatedPulsar, efac: float = 1.0,
         Whether to add measurment noise as
         EFAC * (TOA error + EQUAD) [default] or EFAC * TOA error + EQUAD.
     """
-    # update the added_signals dictionary
     equad_str = 'tnequad' if tnequad else 't2equad'
-    if flags is None:
-        psr.update_added_signals('{}_measurement_noise'.format(psr.name),
-                                 {'efac': efac, 'log10_' + equad_str: log10_equad})
-    else:
-        for i, flag in enumerate(flags):
-            psr.update_added_signals('{}_{}_measurement_noise'.format(psr.name, flag),
-                                     {'efac': efac[i], 'log10_' + equad_str: log10_equad[i]})
 
     if log10_equad is not None:
         equad = 10**log10_equad
@@ -115,6 +107,20 @@ def add_measurement_noise(psr: SimulatedPulsar, efac: float = 1.0,
         dt += equadvec * np.random.randn(psr.toas.ntoas) * u.s
     else:
         dt += efacvec * equadvec * np.random.randn(psr.toas.ntoas) * u.s
+        
+    # update the added_signals dictionary
+    if flags is None:
+        psr.update_added_signals('{}_measurement_noise'.format(psr.name),
+                                 {'efac': efac, 'log10_' + equad_str: log10_equad},
+                                 dt)
+    else:
+        # update added_signals_time dictionary first
+        psr.update_added_signals('{}_measurement_noise'.format(psr.name), {}, dt)
+        # next update added_signals dictionary
+        for i, flag in enumerate(flags):
+            psr.update_added_signals('{}_{}_measurement_noise'.format(psr.name, flag),
+                                     {'efac': efac[i], 'log10_' + equad_str: log10_equad[i]},
+                                     dt)
 
     psr.toas.adjust_TOAs(TimeDelta(dt.to('day')))
     psr.update_residuals()
@@ -143,14 +149,6 @@ def add_jitter(psr: SimulatedPulsar, log10_ecorr: float,
     seed : int
         The seed for the random number generator.
     """
-    # update the added_signals dictionary
-    if flags is None:
-        psr.update_added_signals('{}_jitter'.format(psr.name),
-                                 {'log10_ecorr': log10_ecorr})
-    else:
-        for i, flag in enumerate(flags):
-            psr.update_added_signals('{}_{}_jitter'.format(psr.name, flag),
-                                     {'log10_ecorr': log10_ecorr[i]})
 
     ecorr = 10**log10_ecorr
 
@@ -183,6 +181,19 @@ def add_jitter(psr: SimulatedPulsar, log10_ecorr: float,
             raise ValueError("ERROR: flags must be same length as jitter")
 
     dt = u.s * np.dot(U * ecorrvec, np.random.randn(U.shape[1]))
+    
+    # update the added_signals dictionary
+    if flags is None:
+        psr.update_added_signals('{}_jitter'.format(psr.name),
+                                 {'log10_ecorr': log10_ecorr},
+                                 dt)
+    else:
+        # update added_signals_time dictionary first
+        psr.update_added_signals('{}_jitter'.format(psr.name), {}, dt)
+        # next update added_signal dictionary
+        for i, flag in enumerate(flags):
+            psr.update_added_signals('{}_{}_jitter'.format(psr.name, flag),
+                                     {'log10_ecorr': log10_ecorr[i]})
 
     psr.toas.adjust_TOAs(TimeDelta(dt.to('day')))
     psr.update_residuals()

--- a/pta_replicator/white_noise.py
+++ b/pta_replicator/white_noise.py
@@ -119,8 +119,7 @@ def add_measurement_noise(psr: SimulatedPulsar, efac: float = 1.0,
         # next update added_signals dictionary
         for i, flag in enumerate(flags):
             psr.update_added_signals('{}_{}_measurement_noise'.format(psr.name, flag),
-                                     {'efac': efac[i], 'log10_' + equad_str: log10_equad[i]},
-                                     dt)
+                                     {'efac': efac[i], 'log10_' + equad_str: log10_equad[i]})
 
     psr.toas.adjust_TOAs(TimeDelta(dt.to('day')))
     psr.update_residuals()


### PR DESCRIPTION
I thought it would be useful for the `SimulatedPulsar` object to store the residuals time series from each individual signal, alongside the signal parameters themselves. I've implemented this using the new attribute `SimulatedPulsar.added_signals_time`, which stores a dictionary of residuals arrays. To show this, if you run the example notebook with `npsrs=2` and add the following code block:

```
for psr in psrs:
    plt.errorbar(psr.toas.get_mjds(), psr.residuals.time_resids.to_value("us"),
                 psr.residuals.get_data_error().to_value("us"), marker="+", ls="", label="Total")
    for sig in psr.added_signals_time:
        plt.plot(psr.toas.get_mjds(), psr.added_signals_time[sig].to_value("us"),
                 marker='x', label=sig, ls="", zorder=5, alpha=0.5)
    plt.legend()
    plt.xlabel("MJD")
    plt.ylabel("Residuals (us)")
    plt.show()
    plt.clf()
```

you should get the following plots:

<img width="574" height="432" alt="image" src="https://github.com/user-attachments/assets/eb603b1f-cff2-456d-841e-5aa8a8b42ae8" />

<img width="574" height="432" alt="image" src="https://github.com/user-attachments/assets/68030d0a-7f2c-49a9-812c-a790eee03878" />
