### PR TITLE
feat: port to new format adhering to PEP 508

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,20 @@
-[tool.poetry]
+[project]
 name = "pta_replicator"
 version = "0.1.0"
 description = "Simulate PTA datasets"
-authors = ["Bence Becsy", "Aaron Johnson"]
+authors = [{name="Bence Becsy"}, {name="Aaron Johnson"}]
 readme = "README.md"
 
-[tool.poetry.dependencies]
-python = "^3.9"
-pint-pulsar = "^0.9.8"
-numpy = "^1.26.4"
-astropy = "^6.0.0"
-scipy = "^1.12.0"
-ephem = "^4.1.5"
-numba = "^0.59.0"
-matplotlib = "^3.8.2"
-holodeck-gw = "^1.0"
+dependencies = [
+             "pint-pulsar (>=0.9.8,<2.0.0)",
+             "numpy (>=1.26,<3.0.0)",
+             "astropy (>=6.0.0,<8.0.0)",
+             "scipy (>=1.12.0,<2.0.0)",
+             "ephem (>=4.1.5,<5.0.0)",
+             "numba (>=0.59.0)",
+             "matplotlib (>=3.8.2,<4.0.0)",
+             "holodeck-gw (>=1.0,<2.0.0)",
+]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR ports the pyproject.toml from the Poetry-specific format to the format specified in PEP 508. This makes source installs of this project with other tools like uv and pixi much easier.